### PR TITLE
Bug Fix: Update active member filter and asset references

### DIFF
--- a/TeamWeeklyStatus.Infrastructure/Repositories/WeeklyStatusRepository.cs
+++ b/TeamWeeklyStatus.Infrastructure/Repositories/WeeklyStatusRepository.cs
@@ -120,7 +120,7 @@ namespace TeamWeeklyStatus.Infrastructure.Repositories
             // Get all team members
             var allTeamMembers = await _context.TeamMembers
                 .Include(tm => tm.Member)
-                .Where(tm => tm.TeamId == teamId)
+                .Where(tm => tm.TeamId == teamId && (tm.EndActiveDate == null || (tm.StartActiveDate <= DateTime.Now && tm.EndActiveDate >= DateTime.Now)))
                 .ToListAsync();
 
             // Get existing weekly statuses for the date

--- a/TeamWeeklyStatus.WebApi/wwwroot/index.html
+++ b/TeamWeeklyStatus.WebApi/wwwroot/index.html
@@ -10,8 +10,8 @@
     crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css2?family=Exo:wght@900&family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
     <title>MangoChango - Team Weekly Status</title>
-    <script type="module" crossorigin src="/assets/index-c3c8028d.js"></script>
-    <link rel="stylesheet" href="/assets/index-c9702063.css">
+    <script type="module" crossorigin src="/assets/index-8c489274.js"></script>
+    <link rel="stylesheet" href="/assets/index-dfeede87.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Latest frontend from master branch.

Modified `WeeklyStatusRepository.cs` to include a condition in the LINQ query that filters out inactive team members, ensuring only active members are fetched. Updated `index.html` to reference the latest versions of JavaScript and CSS assets, potentially incorporating new features and bug fixes.