### PR TITLE
Refactor Lambda handlers and update schedules

### DIFF
--- a/team-weekly-status-lambdas/AssignCurrentWeekReporter/index.mjs
+++ b/team-weekly-status-lambdas/AssignCurrentWeekReporter/index.mjs
@@ -2,27 +2,20 @@
 import axios from 'axios';
 
 // Lambda handler function
-// SendReminderSendWeeklyReport
 export const handler = async (event) => {
     try {
         // Define the endpoint URL
-        const url = 'https://misha24.azurewebsites.net//api/WeeklyStatus/SendReminders';
+        const url = 'https://misha24.azurewebsites.net/api/TeamMember/AutomaticAssignCurrentWeekReporter';
 
         // Make the POST request to the provided endpoint
-        const payload = { "eventName": "SendReport"};
-        const response = await axios.post(url, body, {
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(payload),
-        });
+        const response = await axios.post(url);
         
         // Extract the data from the response
         const data = response.data;
 
         // Log the data to CloudWatch
-        console.log('Returned Data:', data);
-
+        console.log('Fetched Data after setting the current week reporter:', data);
+        
         // Return a successful response
         return {
             statusCode: 200,
@@ -36,7 +29,7 @@ export const handler = async (event) => {
         return {
             statusCode: error.response?.status || 500,
             body: JSON.stringify({
-                message: 'Error sending reminder',
+                message: 'Error assigning the current week reporter',
                 error: error.message
             })
         };

--- a/team-weekly-status-lambdas/SendReminders/index.mjs
+++ b/team-weekly-status-lambdas/SendReminders/index.mjs
@@ -2,26 +2,33 @@
 import axios from 'axios';
 
 // Lambda handler function
-// SendReminderPostWeeklyStatus
 export const handler = async (event) => {
     try {
         // Define the endpoint URL
-        const url = 'https://misha24.azurewebsites.net//api/WeeklyStatus/SendReminders';
+        const url = 'https://misha24.azurewebsites.net/api/WeeklyStatus/SendReminders';
 
         // Make the POST request to the provided endpoint
-        const payload = { "eventName": "Post"};
-        const response = await axios.post(url, body, {
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(payload),
-        });
+        let payload = {
+            eventName: "Post"
+        };
+        const response = await axios.post(url, payload);
         
         // Extract the data from the response
         const data = response.data;
 
         // Log the data to CloudWatch
-        console.log('Returned Data:', data);
+        console.log('Fetched Data from Post event:', data);
+        
+        payload = {
+            eventName: "SendReport"
+        }
+        const responseSendReport = await axios.post(url, payload);
+        
+        // Extract the data from the response
+        const dataSendReport = responseSendReport.data;
+
+        // Log the data to CloudWatch
+        console.log('Fetched Data from SendReport event:', dataSendReport);
 
         // Return a successful response
         return {
@@ -36,7 +43,7 @@ export const handler = async (event) => {
         return {
             statusCode: error.response?.status || 500,
             body: JSON.stringify({
-                message: 'Error sending reminder',
+                message: 'Error fetching data',
                 error: error.message
             })
         };

--- a/team-weekly-status-lambdas/schedules/TeamWeeklyStatusAutomaticAssignCurrentWeekReporter.json
+++ b/team-weekly-status-lambdas/schedules/TeamWeeklyStatusAutomaticAssignCurrentWeekReporter.json
@@ -1,0 +1,23 @@
+{
+    "ActionAfterCompletion": "NONE",
+    "Arn": "arn:aws:scheduler:us-east-2:891377130768:schedule/default/TeamWeeklyStatusAutomaticAssignCurrentWeekReporter",
+    "CreationDate": "2024-11-05T08:43:08.263000-06:00",
+    "Description": "",
+    "FlexibleTimeWindow": {
+        "Mode": "OFF"
+    },
+    "GroupName": "default",
+    "LastModificationDate": "2024-11-05T09:03:29.456000-06:00",
+    "Name": "TeamWeeklyStatusAutomaticAssignCurrentWeekReporter",
+    "ScheduleExpression": "cron(0 9 ? * MON *)",
+    "ScheduleExpressionTimezone": "America/Guatemala",
+    "State": "ENABLED",
+    "Target": {
+        "Arn": "arn:aws:lambda:us-east-2:891377130768:function:AssignCurrentWeekReporter",
+        "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+        },
+        "RoleArn": "arn:aws:iam::891377130768:role/service-role/Amazon_EventBridge_Scheduler_LAMBDA_8316541a8e"
+    }
+}

--- a/team-weekly-status-lambdas/schedules/TeamWeeklyStatusSendReminders.json
+++ b/team-weekly-status-lambdas/schedules/TeamWeeklyStatusSendReminders.json
@@ -1,0 +1,23 @@
+{
+    "ActionAfterCompletion": "NONE",
+    "Arn": "arn:aws:scheduler:us-east-2:891377130768:schedule/default/TeamWeeklyStatusSendReminders",
+    "CreationDate": "2024-10-25T07:54:50.110000-06:00",
+    "Description": "",
+    "FlexibleTimeWindow": {
+        "Mode": "OFF"
+    },
+    "GroupName": "default",
+    "LastModificationDate": "2024-11-01T07:51:01.372000-06:00",
+    "Name": "TeamWeeklyStatusSendReminders",
+    "ScheduleExpression": "cron(0 9 ? * FRI *)",
+    "ScheduleExpressionTimezone": "America/Guatemala",
+    "State": "ENABLED",
+    "Target": {
+        "Arn": "arn:aws:lambda:us-east-2:891377130768:function:SendReminders",
+        "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 185
+        },
+        "RoleArn": "arn:aws:iam::891377130768:role/service-role/Amazon_EventBridge_Scheduler_LAMBDA_47755fc7f7"
+    }
+}

--- a/team-weekly-status-lambdas/schedules/schedules.json
+++ b/team-weekly-status-lambdas/schedules/schedules.json
@@ -1,0 +1,26 @@
+{
+    "Schedules": [
+        {
+            "Arn": "arn:aws:scheduler:us-east-2:891377130768:schedule/default/TeamWeeklyStatusAutomaticAssignCurrentWeekReporter",
+            "CreationDate": "2024-11-05T08:43:08.263000-06:00",
+            "GroupName": "default",
+            "LastModificationDate": "2024-11-05T09:03:29.456000-06:00",
+            "Name": "TeamWeeklyStatusAutomaticAssignCurrentWeekReporter",
+            "State": "ENABLED",
+            "Target": {
+                "Arn": "arn:aws:lambda:us-east-2:891377130768:function:AssignCurrentWeekReporter"
+            }
+        },
+        {
+            "Arn": "arn:aws:scheduler:us-east-2:891377130768:schedule/default/TeamWeeklyStatusSendReminders",
+            "CreationDate": "2024-10-25T07:54:50.110000-06:00",
+            "GroupName": "default",
+            "LastModificationDate": "2024-11-01T07:51:01.372000-06:00",
+            "Name": "TeamWeeklyStatusSendReminders",
+            "State": "ENABLED",
+            "Target": {
+                "Arn": "arn:aws:lambda:us-east-2:891377130768:function:SendReminders"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Consolidated reminder and reporter assignment into a single Lambda handler function. Removed separate handlers for `SendReminderPostWeeklyStatus` and `SendReminderSendWeeklyReport`. Added a new handler for assigning the current week reporter via a POST request. Updated `schedules.json` to include the new and existing Lambda functions. Added `TeamWeeklyStatusAutomaticAssignCurrentWeekReporter.json` and `TeamWeeklyStatusSendReminders.json` for scheduling details, including cron expressions, retry policies, and role ARNs.